### PR TITLE
Process all logs in the directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-/vendor
-/build
-composer.lock
-

--- a/src/Commands/Rotate.php
+++ b/src/Commands/Rotate.php
@@ -4,7 +4,6 @@ namespace Cesargb\File\Rotate\Commands;
 
 use Cesargb\File\Rotate as RotateFile;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Artisan;
 
 class Rotate extends Command
 {

--- a/src/Commands/Rotate.php
+++ b/src/Commands/Rotate.php
@@ -13,10 +13,7 @@ class Rotate extends Command
 
     public function handle()
     {
-    	$logs=[
-    		app()->storagePath().'/logs/laravel.log',
-		    app()->storagePath().'/logs/worker.log',
-	    ];
+	    $logs = glob(app()->storagePath().'/logs/*.log');
 
     	foreach ($logs as $logfile){
 		    $result = RotateFile::file(

--- a/src/Commands/Rotate.php
+++ b/src/Commands/Rotate.php
@@ -13,16 +13,22 @@ class Rotate extends Command
 
     public function handle()
     {
-        $result = RotateFile::file(
-            app()->storagePath().'/logs/laravel.log',
-            config('rotate.log_max_files', 7),
-            config('rotate.log_compress_files', true)
-        );
+    	$logs=[
+    		app()->storagePath().'/logs/laravel.log',
+		    app()->storagePath().'/logs/worker.log',
+	    ];
 
-        if ($result) {
-            $this->info('Logs was rotated');
-        } else {
-            $this->error('Logs rotate failed');
-        }
+    	foreach ($logs as $logfile){
+		    $result = RotateFile::file(
+			    $logfile,
+			    config('rotate.log_max_files', 7),
+			    config('rotate.log_compress_files', true)
+		    );
+		    if ($result) {
+			    $this->info('Log '.$logfile.' was rotated');
+		    } else {
+			    $this->error('Log '.$logfile.' rotate failed');
+		    }
+	    }
     }
 }

--- a/src/Commands/Rotate.php
+++ b/src/Commands/Rotate.php
@@ -4,6 +4,7 @@ namespace Cesargb\File\Rotate\Commands;
 
 use Cesargb\File\Rotate as RotateFile;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
 
 class Rotate extends Command
 {
@@ -23,6 +24,7 @@ class Rotate extends Command
 		    );
 		    if ($result) {
 			    $this->info('Log '.$logfile.' was rotated');
+			    touch($logfile);
 		    } else {
 			    $this->error('Log '.$logfile.' rotate failed');
 		    }

--- a/tests/RotateTest.php
+++ b/tests/RotateTest.php
@@ -15,7 +15,7 @@ class RotateTest extends TestCase
         $this->app['config']->set('rotate.log_compress_files', true);
         $this->app['config']->set('rotate.log_max_files', 5);
 
-        $filesOld = glob(app()->storagePath().'/logs/{laravel,worker}*',GLOB_BRACE);
+        $filesOld = glob(app()->storagePath().'/logs/*');
 
         foreach ($filesOld as $f) {
             unlink($f);
@@ -27,15 +27,18 @@ class RotateTest extends TestCase
     {
         Log::info('test');
 
-        $this->assertFileExists(app()->storagePath().'/logs/laravel.log');
-	    $this->assertFileExists(app()->storagePath().'/logs/worker.log');
+	    $logs = glob(app()->storagePath().'/logs/*.log');
+	    foreach($logs as $log){
+		    $this->assertFileExists($log);
+	    }
 
         $resultCode = Artisan::call('logs:rotate');
 
         $this->assertEquals($resultCode, 0);
-        $this->assertFileExists(app()->storagePath().'/logs/laravel.log.1.gz');
-	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.1.gz');
 
+	    foreach($logs as $log){
+		    $this->assertFileExists($log.'.1.gz');
+	    }
     }
 
     /** @test **/
@@ -43,44 +46,42 @@ class RotateTest extends TestCase
     {
         Log::info('test');
 
-        $this->assertFileExists(app()->storagePath().'/logs/laravel.log');
-	    $this->assertFileExists(app()->storagePath().'/logs/worker.log');
+	    $logs = glob(app()->storagePath().'/logs/*.log');
+	    foreach($logs as $log){
+		    $this->assertFileExists($log);
+	    }
 
         $this->app['config']->set('rotate.log_compress_files', false);
 
         $resultCode = Artisan::call('logs:rotate');
 
         $this->assertEquals($resultCode, 0);
-        $this->assertFileExists(app()->storagePath().'/logs/laravel.log.1');
-	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.1');
+	    foreach($logs as $log){
+		    $this->assertFileExists($log.'.1');
+	    }
+
     }
 
     /** @test **/
     public function it_can_rotate_logs_with_maxfiles()
     {
-        $this->app['config']->set('rotate.log_compress_files', true);
+	    $this->app['config']->set('rotate.log_compress_files', true);
 
-        for ($n = 0; $n < 10; $n++) {
-            file_put_contents(app()->storagePath().'/logs/laravel.log', 'test');
-	        file_put_contents(app()->storagePath().'/logs/worker.log', 'test');
-            Artisan::call('logs:rotate');
-        }
+	    $logs = glob(app()->storagePath().'/logs/*.log');
 
-        $filesOld = glob(app()->storagePath().'/logs/{laravel,worker}.log.*.gz',GLOB_BRACE);
+	    for ($n = 0; $n < 10; $n++) {
+		    foreach($logs as $log){
+			    file_put_contents($log, 'test');
+		    }
+		    Artisan::call('logs:rotate');
+	    }
 
-        $this->assertFileExists(app()->storagePath().'/logs/laravel.log.1.gz');
-        $this->assertFileExists(app()->storagePath().'/logs/laravel.log.2.gz');
-        $this->assertFileExists(app()->storagePath().'/logs/laravel.log.3.gz');
-        $this->assertFileExists(app()->storagePath().'/logs/laravel.log.4.gz');
-        $this->assertFileExists(app()->storagePath().'/logs/laravel.log.5.gz');
-        $this->assertFalse(file_exists(app()->storagePath().'/logs/laravel.log.6.gz'));
-
-	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.1.gz');
-	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.2.gz');
-	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.3.gz');
-	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.4.gz');
-	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.5.gz');
-	    $this->assertFalse(file_exists(app()->storagePath().'/logs/worker.log.6.gz'));
-
+	    $filesOld = glob(app()->storagePath().'/logs/*.log.*.gz');
+	    foreach($logs as $log){
+	    	for($i=1;$i<=5;$i++){
+			    $this->assertFileExists($log.'1.gz');
+		    }
+		    $this->assertFalse(file_exists($log.'.6.gz'));
+	    }
     }
 }

--- a/tests/RotateTest.php
+++ b/tests/RotateTest.php
@@ -15,7 +15,7 @@ class RotateTest extends TestCase
         $this->app['config']->set('rotate.log_compress_files', true);
         $this->app['config']->set('rotate.log_max_files', 5);
 
-        $filesOld = glob(app()->storagePath().'/logs/laravel*');
+        $filesOld = glob(app()->storagePath().'/logs/{laravel,worker}*',GLOB_BRACE);
 
         foreach ($filesOld as $f) {
             unlink($f);
@@ -28,11 +28,14 @@ class RotateTest extends TestCase
         Log::info('test');
 
         $this->assertFileExists(app()->storagePath().'/logs/laravel.log');
+	    $this->assertFileExists(app()->storagePath().'/logs/worker.log');
 
         $resultCode = Artisan::call('logs:rotate');
 
         $this->assertEquals($resultCode, 0);
         $this->assertFileExists(app()->storagePath().'/logs/laravel.log.1.gz');
+	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.1.gz');
+
     }
 
     /** @test **/
@@ -41,6 +44,7 @@ class RotateTest extends TestCase
         Log::info('test');
 
         $this->assertFileExists(app()->storagePath().'/logs/laravel.log');
+	    $this->assertFileExists(app()->storagePath().'/logs/worker.log');
 
         $this->app['config']->set('rotate.log_compress_files', false);
 
@@ -48,6 +52,7 @@ class RotateTest extends TestCase
 
         $this->assertEquals($resultCode, 0);
         $this->assertFileExists(app()->storagePath().'/logs/laravel.log.1');
+	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.1');
     }
 
     /** @test **/
@@ -57,10 +62,11 @@ class RotateTest extends TestCase
 
         for ($n = 0; $n < 10; $n++) {
             file_put_contents(app()->storagePath().'/logs/laravel.log', 'test');
+	        file_put_contents(app()->storagePath().'/logs/worker.log', 'test');
             Artisan::call('logs:rotate');
         }
 
-        $filesOld = glob(app()->storagePath().'/logs/laravel.log.*.gz');
+        $filesOld = glob(app()->storagePath().'/logs/{laravel,worker}.log.*.gz',GLOB_BRACE);
 
         $this->assertFileExists(app()->storagePath().'/logs/laravel.log.1.gz');
         $this->assertFileExists(app()->storagePath().'/logs/laravel.log.2.gz');
@@ -68,5 +74,13 @@ class RotateTest extends TestCase
         $this->assertFileExists(app()->storagePath().'/logs/laravel.log.4.gz');
         $this->assertFileExists(app()->storagePath().'/logs/laravel.log.5.gz');
         $this->assertFalse(file_exists(app()->storagePath().'/logs/laravel.log.6.gz'));
+
+	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.1.gz');
+	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.2.gz');
+	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.3.gz');
+	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.4.gz');
+	    $this->assertFileExists(app()->storagePath().'/logs/worker.log.5.gz');
+	    $this->assertFalse(file_exists(app()->storagePath().'/logs/worker.log.6.gz'));
+
     }
 }


### PR DESCRIPTION
Process all logs in the laravel logs directory.

For example, supervisor may write worker.log to the logs directory as well.
https://laravel.com/docs/5.6/queues#supervisor-configuration

Added touch new empty file after rotating because  Queue is not able to recreate log file until queue:restart command given.